### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/prologic/sahriswiki.png?label=ready&title=Ready 
+ :target: https://waffle.io/prologic/sahriswiki
+ :alt: 'Stories in Ready'
 .. _sahriswiki Website: http://sahriswiki.org/
 .. _circuits: https://bitbucket.org/prologic/circuits/
 .. _sahriswiki Page on PyPi: http://pypi.python.org/pypi/sahriswiki


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/prologic/sahriswiki

This was requested by a real person (user prologic) on waffle.io, we're not trying to spam you.
