### PR TITLE
Migrate to Github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM prologic/crux-python
 MAINTAINER James Mills <prologic@shortcircuitnet.au>
 
 # Install Source
-RUN pip install https://bitbucket.org/prologic/sahriswiki/get/tip.tar.bz2#egg=sahriswiki
+RUN pip install https://github.com/prologic/sahriswiki/get/tip.tar.bz2#egg=sahriswiki
 
 # Expose Service
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sahriswiki
 
 [!['Stories in Ready'](https://badge.waffle.io/prologic/sahriswiki.png?label=ready&title=Ready)](https://waffle.io/prologic/sahriswiki)
 
-sahriswiki is a **lightweight** **Wiki Engine** built using the [circuits](https://bitbucket.org/prologic/circuits/) and circuits.web framework framework, is modular, plugable and themeable.
+sahriswiki is a **lightweight** **Wiki Engine** built using the [circuits](https://github.com/circuits/circuits/) and circuits.web framework framework, is modular, plugable and themeable.
 
 sahriswiki aims to implement a core set of features that are a mixture of "best of breed" Wiki, Blog, and CMS features.
 
@@ -11,7 +11,7 @@ sahriswiki aims to implement a core set of features that are a mixture of "best 
 
 **Documentation**: <http://sahriswiki.org/Docs/>
 
-**Project website**: <https://bitbucket.org/prologic/sahriswiki/>
+**Project website**: <https://github.com/prologic/sahriswiki/>
 
 **PyPI page**: <http://pypi.python.org/pypi/sahriswiki>
 
@@ -27,7 +27,7 @@ Requirements
 
 sahriswiki depends on the following software:
 
--   [circuits](https://bitbucket.org/prologic/circuits/)
+-   [circuits](https://github.com/circuits/circuits/)
 -   [Mercurial](http://mercurial.selenic.com/)
 -   [SQLAlchemy](http://www.sqlalchemy.org/)
 -   [creoleparser](http://code.google.com/p/creoleparser/)
@@ -45,7 +45,7 @@ If you do not have pip, you may use easy\_install:
 
     > easy_install sahriswiki
 
-Alternatively, you may download the source package from the [sahriswiki Page on PyPi](http://pypi.python.org/pypi/sahriswiki) or the [sahriswiki Downloads page](https://bitbucket.org/prologic/sahriswiki/downloads) on the [sahriswiki Website](http://sahriswiki.org/); extract it and install using:
+Alternatively, you may download the source package from the [sahriswiki Page on PyPi](http://pypi.python.org/pypi/sahriswiki) or the [sahriswiki Downloads page](https://github.com/prologic/sahriswiki/downloads) on the [sahriswiki Website](http://sahriswiki.org/); extract it and install using:
 
     > python setup.py install
 
@@ -59,4 +59,4 @@ Feedback
 
 I welcome any questions or feedback about bugs and suggestions on how to improve sahriswiki. Let me know what you think about sahriswiki. I am on twitter [@therealprologic](http://twitter.com/therealprologic).
 
-Do you have suggestions for improvement? Then please [Create an Issue](https://bitbucket.org/prologic/sahriswiki/issue/new) with details of what you would like to see. I'll take a look at it and work with you to either incorporate the idea or find a better solution.
+Do you have suggestions for improvement? Then please [Create an Issue](https://github.com/prologic/sahriswiki/issue/new) with details of what you would like to see. I'll take a look at it and work with you to either incorporate the idea or find a better solution.

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 .. _sahriswiki Website: http://sahriswiki.org/
-.. _circuits: https://bitbucket.org/prologic/circuits/
+.. _circuits: https://github.com/circuits/circuits/
 .. _sahriswiki Page on PyPi: http://pypi.python.org/pypi/sahriswiki
 .. _MIT License: http://www.opensource.org/licenses/mit-license.php
-.. _Create an Issue: https://bitbucket.org/prologic/sahriswiki/issue/new
-.. _sahriswiki Downloads page: https://bitbucket.org/prologic/sahriswiki/downloads
+.. _Create an Issue: https://github.com/prologic/sahriswiki/issue/new
+.. _sahriswiki Downloads page: https://github.com/prologic/sahriswiki/downloads
 
 
 sahriswiki
@@ -24,7 +24,7 @@ of "best of breed" Wiki, Blog, and CMS features.
 
 **Documentation**: http://sahriswiki.org/Docs/
 
-**Project website**: https://bitbucket.org/prologic/sahriswiki/
+**Project website**: https://github.com/prologic/sahriswiki/
 
 **PyPI page**: http://pypi.python.org/pypi/sahriswiki
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="James Mills",
     author_email="James Mills, prologic at shortcircuit dot net dot au",
     url="http://sahriswiki.org/",
-    download_url="http://bitbucket.org/prologic/sahriswiki/downloads/",
+    download_url="http://github.com/prologic/sahriswiki/downloads/",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Plugins",

--- a/wiki/Docs/Development/Index
+++ b/wiki/Docs/Development/Index
@@ -1,7 +1,7 @@
 = Development =
 
-Please visit the bitbucket
-[[http://bitbucket.org/prologic/sahriswiki/|SahrisWiki Development Site]] to:
+Please visit the GitHub
+[[http://github.com/prologic/sahriswiki/|SahrisWiki Development Site]] to:
 * Follow Development
 * File a Bug Report
 * File a Feature Reuqest

--- a/wiki/Docs/Downloading
+++ b/wiki/Docs/Downloading
@@ -1,12 +1,11 @@
 = Downloading =
 
 [[SahrisWiki]] can be downloaded from:
- * Latest Snapshots: [[https://bitbucket.org/prologic/sahriswiki/downloads|Bitbucket]]
  * Latest Releases: [[http://pypi.python.org/pypi/sahriswiki/|PyPi]]
 
 Alternatively you can download [[SahrisWiki]] by using [[http://mercurial.selenic.com/|Mercurial]] and cloning the repository:
 <<code lang="sh">>
-$ hg clone https://bitbucket.org/prologic/sahriswiki/
+$ hg clone https://github.com/prologic/sahriswiki/
 <</code>>
 
 For installation instructions see [[Docs/Installing]]

--- a/wiki/Docs/Installing
+++ b/wiki/Docs/Installing
@@ -5,7 +5,7 @@ To install [[SahrisWiki]] run the following command:
 $ python setup.py install
 <</code>>
 
-If you have cloned the [[http://bitbucket.org/prologic/sahriswiki/|SahrisWiki Repository]] and have [[http://pypi.python.org/pypi/setuptools|setuptools]] installed, then you can follow the development and keep up-to-date easily by building and installing in //develop// mode:
+If you have cloned the [[http://github.com/prologic/sahriswiki/|SahrisWiki Repository]] and have [[http://pypi.python.org/pypi/setuptools|setuptools]] installed, then you can follow the development and keep up-to-date easily by building and installing in //develop// mode:
 <<code lang="sh">>
 $ python setup.py build develop
 <</code>>

--- a/wiki/Docs/Performance
+++ b/wiki/Docs/Performance
@@ -1,6 +1,6 @@
 = Performance =
 
-* [[SahrisWiki]] is built using [[http://bitbucket.org/prologic/circuits/|circuits]]'s
+* [[SahrisWiki]] is built using [[https://github.com/circuits/circuits/|circuits]]'s
   lightweight web framework (//circuits.web//) which is itself a fast, scalable, and very powerful asynchronous web application server and framework.
 * [[SahrisWiki]] has an **A** grade [[http://developer.yahoo.com/yslow/|YSlow]] rating and employs all of the techniques that apply to high performance web applications.
 

--- a/wiki/Docs/Requirements
+++ b/wiki/Docs/Requirements
@@ -3,7 +3,7 @@
 
 [[SahrisWiki]] requires and depends on the following software:
 * [[http://www.python.org|Python]]
-* [[http://bitbucket.org/prologic/circuits/|circuits]] //Application Server//
+* [[http://github.com/circuits/circuits/|circuits]] //Application Server//
 * [[http://mercurial.selenic.com/|Mercurial]] //Wiki Storage//
 * [[http://www.sqlalchemy.org/|SQLAlchemy]] //Meta Data Storage//
 * [[http://genshi.edgewall.org/|genshi]] //Templates//

--- a/wiki/FrontPage
+++ b/wiki/FrontPage
@@ -24,13 +24,9 @@ Ensure you have: [[http://www.python.org/|Python]], [[http://pypi.python.org/pyp
 
 Then perform the following steps:
 <<code lang="sh">>
-$ hg clone https://bitbucket.org/prologic/circuits-dev/
-$ cd circuits-dev
-$ python setup.py develop
-
-$ hg clone https://bitbucket.org/prologic/sahriswiki/
+$ git clone https://github.com/prologic/sahriswiki/
 $ cd sahriswiki
-$ python setup.py develop
+$ pip install -e .
 
 $ sahriswiki --help
 <</code>>

--- a/wiki/News
+++ b/wiki/News
@@ -1,6 +1,13 @@
 = News =
 //[[SahrisWiki]] News, Updates and Releases//
 
+== 2nd January 2016 ==
+Moved to [[https://github.com/prologic/sahriswiki|prologic/sahriswiki]]
+over at [[https://github.com/|GitHub]].
+
+Finally after nearly ~2 years the project and software will get some much
+needed love and care.
+
 == 28th January 2013 ==
 After several years of inactivity and neglect some development has continued and a new release will be published soon.
 

--- a/wiki/Support
+++ b/wiki/Support
@@ -2,7 +2,7 @@
 
 * Have a problem with [[SahrisWiki]] ?
 
-[[https://bitbucket.org/prologic/sahriswiki/issues/new|Create an Issue/Ticket]]
+[[https://github.com/prologic/sahriswiki/issues/new|Create an Issue/Ticket]]
 
 * Need help installing ?
 * Got some great feedback ?


### PR DESCRIPTION
Chnages all references to Bitbucket and replaces them with Github.

Closes #1
